### PR TITLE
Specify proxy in custom Transport

### DIFF
--- a/api_vca.go
+++ b/api_vca.go
@@ -253,7 +253,12 @@ func NewVAClient() (*VAClient, error) {
 		Client: Client{
 			APIVersion: "5.6",
 			// Patching things up as we're hitting several TLS timeouts.
-			Http: http.Client{Transport: &http.Transport{TLSHandshakeTimeout: 120 * time.Second}},
+			Http: http.Client{
+				Transport: &http.Transport{
+					Proxy:               http.ProxyFromEnvironment,
+					TLSHandshakeTimeout: 120 * time.Second,
+				},
+			},
 		},
 	}
 	return &VAClient, nil

--- a/api_vcd.go
+++ b/api_vcd.go
@@ -173,7 +173,12 @@ func NewVCDClient(vcdEndpoint url.URL) *VCDClient {
 		Client: Client{
 			APIVersion: "5.5",
 			VCDVDCHREF: vcdEndpoint,
-			Http:       http.Client{Transport: &http.Transport{TLSHandshakeTimeout: 120 * time.Second}},
+			Http: http.Client{
+				Transport: &http.Transport{
+					Proxy:               http.ProxyFromEnvironment,
+					TLSHandshakeTimeout: 120 * time.Second,
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Seems like all parameters must be specified when customising the http Transport.
