### PR TITLE
Allow vApp IP address to be allocated from pool

### DIFF
--- a/vapp.go
+++ b/vapp.go
@@ -672,17 +672,30 @@ func (v *VApp) ChangeNetworkConfig(network, ip string) (Task, error) {
 		return Task{}, fmt.Errorf("vApp doesn't contain any children, aborting customization")
 	}
 
+	// Determine what type of address is requested for the vApp
+	ipAllocationMode := "NONE"
+	ipAddress := "Any"
+
+	// TODO: Review current behaviour of using DHCP when left blank
+	if ip == "" || ip == "dhcp" {
+		ipAllocationMode = "DHCP"
+	} else if ip == "allocated" {
+		ipAllocationMode = "POOL"
+	} else if ip == "none" {
+		ipAllocationMode = "NONE"
+	} else if ip != "" {
+		ipAllocationMode = "MANUAL"
+		// TODO: Check a valid IP has been given
+		ipAddress = ip
+	}
+
 	networkConnection := &types.NetworkConnection{
 		Network:                 network,
 		NeedsCustomization:      true,
 		NetworkConnectionIndex:  0,
-		IPAddress:               ip,
+		IPAddress:               ipAddress,
 		IsConnected:             true,
-		IPAddressAllocationMode: "MANUAL",
-	}
-
-	if ip == "" {
-		networkConnection.IPAddressAllocationMode = "DHCP"
+		IPAddressAllocationMode: ipAllocationMode,
 	}
 
 	newnetwork := &types.NetworkConnectionSection{


### PR DESCRIPTION
This allows the IP address for a vApp to be allocated from the static pool as per:
https://www.vmware.com/support/vcd/doc/rest-api-doc-1.5-html/types/NetworkConnectionType.html

For now I've kept the existing behaviour of a blank string meaning DHCP but that should probably be reviewed.

Note that I've chosen to use the `Any` string as per the `IpAddressType`:
https://www.vmware.com/support/vcd/doc/rest-api-doc-1.5-html/types/IpAddressType.html

Have left a note about IPV4 address validation. Should there be a helper function or should this package pull in an existing library which can do the validation?

Happy to work on tests with some guidance.
