### PR TITLE
Add support for Query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ type Config struct {
 	Org      string
 	Href     string
 	VDC      string
+	Insecure bool
 }
 
 func (c *Config) Client() (*govcd.VCDClient, error) {
@@ -30,7 +31,7 @@ func (c *Config) Client() (*govcd.VCDClient, error) {
 		return nil, fmt.Errorf("Unable to pass url: %s", err)
 	}
 
-	vcdclient := govcd.NewVCDClient(*u)
+	vcdclient := govcd.NewVCDClient(*u, c.Insecure)
 	org, vcd, err := vcdclient.Authenticate(c.User, c.Password, c.Org, c.VDC)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to authenticate: %s", err)

--- a/api_vcd.go
+++ b/api_vcd.go
@@ -114,7 +114,7 @@ func (c *VCDClient) vcdauthorize(user, pass, org string) error {
 				return fmt.Errorf("couldn't find a Query API in current session, %v", err)
 			}
 			c.QueryHREF = *u
-		}		
+		}
 	}
 	if !org_found {
 		return fmt.Errorf("couldn't find a Organization in current session")
@@ -175,7 +175,6 @@ func (c *VCDClient) RetrieveOrg(vcdname string) (Org, error) {
 
 	return *org, nil
 }
-
 
 func NewVCDClient(vcdEndpoint url.URL, insecure bool) *VCDClient {
 

--- a/api_vcd.go
+++ b/api_vcd.go
@@ -98,7 +98,7 @@ func (c *VCDClient) vcdauthorize(user, pass, org string) error {
 	}
 
 	org_found := false
-	// Loop in the session struct to find the organization.
+	// Loop in the session struct to find the organization and query api.
 	for _, s := range session.Link {
 		if s.Type == "application/vnd.vmware.vcloud.org+xml" && s.Rel == "down" {
 			u, err := url.Parse(s.HREF)
@@ -108,6 +108,13 @@ func (c *VCDClient) vcdauthorize(user, pass, org string) error {
 			c.OrgHREF = *u
 			org_found = true
 		}
+		if s.Type == "application/vnd.vmware.vcloud.query.queryList+xml" && s.Rel == "down" {
+			u, err := url.Parse(s.HREF)
+			if err != nil {
+				return fmt.Errorf("couldn't find a Query API in current session, %v", err)
+			}
+			c.QueryHREF = *u
+		}		
 	}
 	if !org_found {
 		return fmt.Errorf("couldn't find a Organization in current session")
@@ -171,8 +178,6 @@ func (c *VCDClient) RetrieveOrg(vcdname string) (Org, error) {
 
 
 func NewVCDClient(vcdEndpoint url.URL, insecure bool) *VCDClient {
-    QueryHREF := vcdEndpoint
-    QueryHREF.Path += "/query"
 
 	return &VCDClient{
 		Client: Client{
@@ -188,7 +193,6 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool) *VCDClient {
 				},
 			},
 		},
-		QueryHREF: QueryHREF,
 	}
 }
 

--- a/api_vcd.go
+++ b/api_vcd.go
@@ -16,6 +16,7 @@ type VCDClient struct {
 	OrgVdc      Vdc     // Org vDC
 	Client      Client  // Client for the underlying VCD instance
 	sessionHREF url.URL // HREF for the session API
+	QueryHREF   url.URL // HREF for the query API
 	Mutex       sync.Mutex
 }
 
@@ -168,7 +169,10 @@ func (c *VCDClient) RetrieveOrg(vcdname string) (Org, error) {
 	return *org, nil
 }
 
+
 func NewVCDClient(vcdEndpoint url.URL, insecure bool) *VCDClient {
+    QueryHREF := vcdEndpoint
+    QueryHREF.Path += "/query"
 
 	return &VCDClient{
 		Client: Client{
@@ -184,6 +188,7 @@ func NewVCDClient(vcdEndpoint url.URL, insecure bool) *VCDClient {
 				},
 			},
 		},
+		QueryHREF: QueryHREF,
 	}
 }
 

--- a/query.go
+++ b/query.go
@@ -12,7 +12,7 @@ import (
 
 type Results struct {
 	Results *types.QueryResultRecordsType
-	c       *Client	
+	c       *Client
 }
 
 func NewResults(c *Client) *Results {

--- a/query.go
+++ b/query.go
@@ -6,8 +6,6 @@ package govcd
 
 import (
 	"fmt"
-	// "net/http/httputil"
-	"log"
 
 	types "github.com/hmrc/vmware-govcd/types/v56"
 )
@@ -24,25 +22,15 @@ func NewResults(c *Client) *Results {
 	}
 }
 
-// func debug(data []byte, err error) {
-//     if err == nil {
-//         fmt.Printf("%s\n\n", data)
-//     } else {
-//         log.Fatalf("%s\n\n", err)
-//     }
-// }
-
 func (c *VCDClient) Query(params map[string]string) (Results, error) {
 
 	req := c.Client.NewRequest(params, "GET", c.QueryHREF, nil)
 	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version=5.5")
-	// debug(httputil.DumpRequestOut(req, true))
 
 	resp, err := checkResp(c.Client.Http.Do(req))
 	if err != nil {
 		return Results{}, fmt.Errorf("error retreiving query: %s", err)
 	}
-	// debug(httputil.DumpResponse(resp, true))
 
 	results := NewResults(&c.Client)
 

--- a/query.go
+++ b/query.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	"fmt"
+	// "net/url"
+	// "net/http"
+	"net/http/httputil"
+	"log"
+
+	types "github.com/hmrc/vmware-govcd/types/v56"
+)
+
+type Results struct {
+	Results *types.QueryResultRecordsType
+	c       *Client	
+}
+
+func NewResults(c *Client) *Results {
+	return &Results{
+		Results: new(types.QueryResultRecordsType),
+		c:       c,
+	}
+}
+
+func debug(data []byte, err error) {
+    if err == nil {
+        fmt.Printf("%s\n\n", data)
+    } else {
+        log.Fatalf("%s\n\n", err)
+    }
+}
+
+func (c *VCDClient) Query(params map[string]string) (Results, error) {
+
+	req := c.Client.NewRequest(params, "GET", c.QueryHREF, nil)
+	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version=5.5")
+	debug(httputil.DumpRequestOut(req, true))
+
+	// TODO: wrap into checkresp to parse error
+	resp, err := checkResp(c.Client.Http.Do(req))
+	if err != nil {
+		return Results{}, fmt.Errorf("error retreiving query: %s", err)
+	}
+	debug(httputil.DumpResponse(resp, true))
+
+	// org := NewOrg(&c.Client)
+	results := NewResults(&c.Client)
+
+	if err = decodeBody(resp, results.Results); err != nil {
+		return Results{}, fmt.Errorf("error decoding query results: %s", err)
+	}
+
+	// // Get the VDC ref from the Org
+	// for _, s := range org.Org.Link {
+	// 	if s.Type == "application/vnd.vmware.vcloud.vdc+xml" && s.Rel == "down" {
+	// 		if vcdname != "" && s.Name != vcdname {
+	// 			continue
+	// 		}
+	// 		u, err := url.Parse(s.HREF)
+	// 		if err != nil {
+	// 			return Org{}, err
+	// 		}
+	// 		c.Client.VCDVDCHREF = *u
+	// 	}
+	// }
+
+	// if &c.Client.VCDVDCHREF == nil {
+	// 	return Org{}, fmt.Errorf("error finding the organization VDC HREF")
+	// }
+
+	return *results, nil
+}

--- a/query.go
+++ b/query.go
@@ -1,14 +1,12 @@
 /*
- * Copyright 2014 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.
+ * Copyright 2016 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.
  */
 
 package govcd
 
 import (
 	"fmt"
-	// "net/url"
-	// "net/http"
-	"net/http/httputil"
+	// "net/http/httputil"
 	"log"
 
 	types "github.com/hmrc/vmware-govcd/types/v56"
@@ -26,51 +24,31 @@ func NewResults(c *Client) *Results {
 	}
 }
 
-func debug(data []byte, err error) {
-    if err == nil {
-        fmt.Printf("%s\n\n", data)
-    } else {
-        log.Fatalf("%s\n\n", err)
-    }
-}
+// func debug(data []byte, err error) {
+//     if err == nil {
+//         fmt.Printf("%s\n\n", data)
+//     } else {
+//         log.Fatalf("%s\n\n", err)
+//     }
+// }
 
 func (c *VCDClient) Query(params map[string]string) (Results, error) {
 
 	req := c.Client.NewRequest(params, "GET", c.QueryHREF, nil)
 	req.Header.Add("Accept", "vnd.vmware.vcloud.org+xml;version=5.5")
-	debug(httputil.DumpRequestOut(req, true))
+	// debug(httputil.DumpRequestOut(req, true))
 
-	// TODO: wrap into checkresp to parse error
 	resp, err := checkResp(c.Client.Http.Do(req))
 	if err != nil {
 		return Results{}, fmt.Errorf("error retreiving query: %s", err)
 	}
-	debug(httputil.DumpResponse(resp, true))
+	// debug(httputil.DumpResponse(resp, true))
 
-	// org := NewOrg(&c.Client)
 	results := NewResults(&c.Client)
 
 	if err = decodeBody(resp, results.Results); err != nil {
 		return Results{}, fmt.Errorf("error decoding query results: %s", err)
 	}
-
-	// // Get the VDC ref from the Org
-	// for _, s := range org.Org.Link {
-	// 	if s.Type == "application/vnd.vmware.vcloud.vdc+xml" && s.Rel == "down" {
-	// 		if vcdname != "" && s.Name != vcdname {
-	// 			continue
-	// 		}
-	// 		u, err := url.Parse(s.HREF)
-	// 		if err != nil {
-	// 			return Org{}, err
-	// 		}
-	// 		c.Client.VCDVDCHREF = *u
-	// 	}
-	// }
-
-	// if &c.Client.VCDVDCHREF == nil {
-	// 	return Org{}, fmt.Errorf("error finding the organization VDC HREF")
-	// }
 
 	return *results, nil
 }

--- a/query_test.go
+++ b/query_test.go
@@ -5,9 +5,9 @@
 package govcd
 
 import (
- 	// "fmt"
-	. "gopkg.in/check.v1"
+	// "fmt"
 	"github.com/hmrc/vmware-govcd/testutil"
+	. "gopkg.in/check.v1"
 )
 
 func (s *K) Test_Query(c *C) {
@@ -17,14 +17,14 @@ func (s *K) Test_Query(c *C) {
 		"/api/query?type=vm": testutil.Response{200, nil, queryVmExample},
 	})
 
-	results, err := s.client.Query( map[string]string{"type": "vm"} )
+	results, err := s.client.Query(map[string]string{"type": "vm"})
 	_ = testServer.WaitRequest()
 	testServer.Flush()
 
 	c.Assert(err, IsNil)
 	c.Assert(results.Results.Total, Equals, 4)
-	c.Assert(len(results.Results.VMRecord), Equals, 4 )
-} 
+	c.Assert(len(results.Results.VMRecord), Equals, 4)
+}
 
 var queryVmExample = `<?xml version="1.0" encoding="UTF-8"?>
 <QueryResultRecords xmlns="http://www.vmware.com/vcloud/v1.5" name="vm" page="1" pageSize="25" total="4" href="http://localhost:4444/api/query?type=vm&amp;page=1&amp;pageSize=25&amp;format=records" type="application/vnd.vmware.vcloud.query.records+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.10.6.15/api/v1.5/schema/master.xsd">

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+ 	// "fmt"
+	. "gopkg.in/check.v1"
+	"github.com/hmrc/vmware-govcd/testutil"
+)
+
+func (s *K) Test_Query(c *C) {
+
+	// Get the Org populated
+	testServer.ResponseMap(1, testutil.ResponseMap{
+		"/api/query?type=vm": testutil.Response{200, nil, queryVmExample},
+	})
+
+	results, err := s.client.Query( map[string]string{"type": "vm"} )
+	_ = testServer.WaitRequest()
+	testServer.Flush()
+
+	c.Assert(err, IsNil)
+	c.Assert(results.Results.Total, Equals, 4)
+	c.Assert(len(results.Results.VMRecord), Equals, 4 )
+} 
+
+var queryVmExample = `<?xml version="1.0" encoding="UTF-8"?>
+<QueryResultRecords xmlns="http://www.vmware.com/vcloud/v1.5" name="vm" page="1" pageSize="25" total="4" href="http://localhost:4444/api/query?type=vm&amp;page=1&amp;pageSize=25&amp;format=records" type="application/vnd.vmware.vcloud.query.records+xml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.10.6.15/api/v1.5/schema/master.xsd">
+    <Link rel="alternate" href="http://localhost:4444/api/query?type=vm&amp;page=1&amp;pageSize=25&amp;format=references" type="application/vnd.vmware.vcloud.query.references+xml"/>
+    <Link rel="alternate" href="http://localhost:4444/api/query?type=vm&amp;page=1&amp;pageSize=25&amp;format=idrecords" type="application/vnd.vmware.vcloud.query.idrecords+xml"/>
+    <VMRecord container="http://localhost:4444/api/vApp/vapp-11111111-1111-1111-1111-111111111111" containerName="jenkins01" guestOs="CentOS 4/5/6/7 (64-bit)" hardwareVersion="9" isBusy="false" isDeleted="false" isDeployed="true" isInMaintenanceMode="false" isPublished="false" isVAppTemplate="false" memoryMB="2048" name="jenkins01" numberOfCpus="2" status="POWERED_ON" storageProfileName="BASIC-Any" vdc="http://localhost:4444/api/vdc/55555555-5555-5555-5555-555555555555" href="http://localhost:4444/api/vApp/vm-66666666-6666-6666-6666-666666666666" isVdcEnabled="true" pvdcHighestSupportedHardwareVersion="9" taskStatus="success" task="http://localhost:4444/api/task/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" taskDetails=" " vmToolsVersion="2147483647" networkName="Development Network" taskStatusName="vappDeploy"/>
+    <VMRecord container="http://localhost:4444/api/vApp/vapp-22222222-2222-2222-2222-222222222222" containerName="Hipchat" guestOs="Ubuntu Linux (64-bit)" hardwareVersion="9" isBusy="false" isDeleted="false" isDeployed="true" isInMaintenanceMode="false" isPublished="false" isVAppTemplate="false" memoryMB="4096" name="hipchat01" numberOfCpus="4" status="POWERED_ON" storageProfileName="BASIC-Any" vdc="http://localhost:4444/api/vdc/55555555-5555-5555-5555-555555555555" href="http://localhost:4444/api/vApp/vm-77777777-7777-7777-7777-777777777777" isVdcEnabled="true" pvdcHighestSupportedHardwareVersion="9" taskStatus="success" task="http://localhost:4444/api/task/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" taskDetails=" " vmToolsVersion="2147483647" networkName="Development Network" taskStatusName="metadataUpdate"/>
+    <VMRecord container="http://localhost:4444/api/vApp/vapp-33333333-3333-3333-3333-333333333333" containerName="TestVMXNET3" guestOs="CentOS 4/5/6/7 (64-bit)" hardwareVersion="9" isBusy="false" isDeleted="false" isDeployed="false" isInMaintenanceMode="false" isPublished="false" isVAppTemplate="false" memoryMB="512" name="testvmxnet" numberOfCpus="1" status="POWERED_OFF" storageProfileName="BASIC-Any" vdc="http://localhost:4444/api/vdc/55555555-5555-5555-5555-555555555555" href="http://localhost:4444/api/vApp/vm-88888888-8888-8888-8888-888888888888" isVdcEnabled="true" pvdcHighestSupportedHardwareVersion="9" taskStatus="success" task="http://localhost:4444/api/task/cccccccc-cccc-cccc-cccc-cccccccccccc" taskDetails=" " vmToolsVersion="2147483647" networkName="Development Network" taskStatusName="metadataUpdate"/>
+    <VMRecord catalogName="DevOps" container="http://localhost:4444/api/vAppTemplate/vappTemplate-44444444-4444-4444-4444-444444444444" containerName="centos71" guestOs="CentOS 4/5/6/7 (64-bit)" hardwareVersion="9" isBusy="false" isDeleted="false" isDeployed="false" isInMaintenanceMode="false" isPublished="false" isVAppTemplate="true" memoryMB="512" name="centos71" numberOfCpus="1" status="POWERED_OFF" storageProfileName="BASIC-Any" vdc="http://localhost:4444/api/vdc/55555555-5555-5555-5555-555555555555" href="http://localhost:4444/api/vAppTemplate/vm-99999999-9999-9999-9999-999999999999" isVdcEnabled="true" pvdcHighestSupportedHardwareVersion="9" vmToolsVersion="2147483647"/>
+</QueryResultRecords>
+	`

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1505,6 +1505,8 @@ type QueryResultRecordsType struct {
 	Link              []*Link                           `xml:"Link,omitempty"`    // A reference to an entity or operation associated with this object.
 	EdgeGatewayRecord *QueryResultEdgeGatewayRecordType `xml:"EdgeGatewayRecord"` // A record representing a query result.
 	VMRecord          []*QueryResultVMRecordType        `xml:"VMRecord"`          // A record representing a VM result.
+	VAppRecord        []*QueryResultVAppRecordType      `xml:"VAppRecord"`        // A record representing a VApp result.
+	OrgVdcStorageProfileRecord []*QueryResultOrgVdcStorageProfileRecordType `xml:"OrgVdcStorageProfileRecord"` // A record representing storage profiles
 }
 
 
@@ -1550,4 +1552,55 @@ type QueryResultVMRecordType struct {
 	TaskStatusName      string `xml:"taskStatusName,attr,omitempty"`
 	TaskDetails         string `xml:"taskDetails,attr,omitempty"`
 	TaskStatus          string `xml:"TaskStatus,attr,omitempty"`
+}
+
+// QueryResultVAppRecordType represents a VM record as query result.
+type QueryResultVAppRecordType struct {
+	// Attributes
+	HREF                  string `xml:"href,attr,omitempty"`                  // The URI of the entity.
+	Name                  string `xml:"name,attr"`                            // The name of the entity.
+	CreationDate          string `xml:"creationDate,attr,omitempty"`          // Creation date/time of the vApp.
+	Busy                  bool   `xml:"isBusy,attr,omitempty"`
+	Deployed              bool   `xml:"isDeployed,attr,omitempty"`            // True if the vApp is deployed.
+	Enabled               bool   `xml:"isEnabled,attr,omitempty"`
+	Expired               bool   `xml:"isExpired,attr,omitempty"`
+	MaintenanceMode       bool   `xml:"isInMaintenanceMode,attr,omitempty"`
+	Public                bool   `xml:"isPublic,attr,omitempty"`
+	OwnerName             string `xml:"ownerName,attr,omitempty"`
+	Status                string `xml:"status,attr,omitempty"`
+	VdcHREF               string `xml:"vdc,attr,omitempty"`
+	VdcName               string `xml:"vdcName,attr,omitempty"`
+	NumberOfVMs           int    `xml:"numberOfVMs,attr,omitempty"`
+	NumberOfCPUs          int    `xml:"numberOfCpus,attr,omitempty"`
+	CpuAllocationMhz      int    `xml:"cpuAllocationMhz,attr,omitempty"`
+	CpuAllocationInMhz    int    `xml:"cpuAllocationInMhz,attr,omitempty"`
+	StorageKB             int    `xml:"storageKB,attr,omitempty"`
+	MemoryAllocationMB    int    `xml:"memoryAllocationMB,attr,omitempty"`
+	AutoDeleteNotified    bool   `xml:"isAutoDeleteNotified,attr,omitempty"`
+	AutoUndeployNotified  bool   `xml:"isAutoUndeployNotified,attr,omitempty"`
+	VdcEnabled            bool   `xml:"isVdcEnabled, attr,omitempty"`
+	HonorBootOrder        bool   `xml:"honorBookOrder,attr,omitempty"`
+	HighestSupportedVersion int `xml:"pvdcHighestSupportedHardwareVersion,attr,omitempty"`
+	LowestHardwareVersion int    `xml:"lowestHardwareVersionInVApp,attr,omitempty"`
+	TaskHREF              string `xml:"task,attr,omitempty"`
+	TaskStatusName        string `xml:"taskStatusName,attr,omitempty"`
+	TaskStatus            string `xml:"TaskStatus,attr,omitempty"`
+	TaskDetails           string `xml:"taskDetails,attr,omitempty"`
+}
+
+
+// QueryResultOrgVdcStorageProfileRecordType represents a storage
+// profile as query result.
+type QueryResultOrgVdcStorageProfileRecordType struct {
+	// Attributes
+	HREF                string `xml:"href,attr,omitempty"`                // The URI of the entity.
+	Name                string `xml:"name,attr,omitempty"`                // Storage Profile name.
+	VdcHREF             string `xml:"vdc,attr,omitempty"`
+	VdcName             string `xml:"vdcName,attr,omitempty"`
+	IsDefaultStorageProfile bool `xml:"isDefaultStorageProfile,attr,omitempty"`
+	IsEnabled           bool   `xml:"isEnabled,attr,omitempty"`
+	IsVdcBusy           bool   `xml:"isVdcBusy,attr,omitempty"`
+	NumberOfConditions  int    `xml:"numberOfConditions,attr,omitempty"`
+	StorageUsedMB       int    `xml:"storageUsedMB,attr,omitempty"`
+	StorageLimitMB      int    `xml:"storageLimitMB,attr,omitempty"`
 }

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -877,16 +877,88 @@ type VM struct {
 	// Section OVF_Section `xml:"Section,omitempty"
 	DateCreated string `xml:"DateCreated,omitempty"` // Creation date/time of the vApp.
 
+	// Section ovf:VirtualHardwareSection
+	VirtualHardwareSection    *VirtualHardwareSection    `xml:"VirtualHardwareSection,omitempty"`
+
 	// FIXME: Upstream bug? Missing NetworkConnectionSection
 	NetworkConnectionSection *NetworkConnectionSection `xml:"NetworkConnectionSection,omitempty"`
 
 	VAppScopedLocalID string `xml:"VAppScopedLocalId,omitempty"` // A unique identifier for the virtual machine in the scope of the vApp.
+
+	Snapshots      *SnapshotSection `xml:"SnapshotSection,omitempty"`
 
 	// TODO: OVF Sections to be implemented
 	// Environment OVF_Environment `xml:"Environment,omitempty"
 
 	VMCapabilities *VMCapabilities `xml:"VmCapabilities,omitempty"` // Allows you to specify certain capabilities of this virtual machine.
 	StorageProfile *Reference      `xml:"StorageProfile,omitempty"` // A reference to a storage profile to be used for this object. The specified storage profile must exist in the organization vDC that contains the object. If not specified, the default storage profile for the vDC is used.
+}
+
+// ovf:VirtualHardwareSection from VM struct
+type VirtualHardwareSection struct {
+	// Extends OVF Section_Type
+	XMLName                  xml.Name              `xml:"VirtualHardwareSection"`
+	Xmlns                    string                `xml:"vcloud,attr,omitempty"`
+
+	Info                     string                `xml:"Info"`
+	HREF                     string                `xml:"href,attr,omitempty"`
+	Type                     string                `xml:"type,attr,omitempty"`
+	Item                   []*VirtualHardwareItem  `xml:"Item,omitempty"`
+}
+
+// Each ovf:Item parsed from the ovf:VirtualHardwareSection
+type VirtualHardwareItem struct {
+	XMLName             xml.Name                     `xml:"Item"`
+	ResourceType        int                          `xml:"ResourceType,omitempty"`
+	ResourceSubType     string                       `xml:"ResourceSubType,omitempty"`
+	ElementName         string                       `xml:"ElementName,omitempty"`
+	Description         string                       `xml:"Description,omitempty"`
+	InstanceID          int                          `xml:"InstanceID,omitempty"`
+	AutomaticAllocation bool                         `xml:"AutomaticAllocation,omitempty"`
+	Address             string                       `xml:"Address,omitempty"`
+	AddressOnParent     int                          `xml:"AddressOnParent,omitempty"`
+	AllocationUnits     string                       `xml:"AllocationUnits,omitempty"`
+	Reservation         int                          `xml:"Reservation,omitempty"`
+	VirtualQuantity     int                          `xml:"VirtualQuantity,omitempty"`
+	Weight              int                          `xml:"Weight,omitempty"`
+	CoresPerSocket      int                          `xml:"CoresPerSocket,omitempty"`
+	Connection       []*VirtualHardwareConnection    `xml:"Connection,omitempty"`
+	HostResource     []*VirtualHardwareHostResource  `xml:"HostResource,omitempty"`
+	Link             []*Link                         `xml:"Link,omitempty"`
+}
+
+// Connection info from ResourceType=10 (Network Interface)
+type VirtualHardwareConnection struct {
+	IPAddress           string   `xml:"ipAddress,attr,omitempty"`
+	PrimaryConnection   bool     `xml:"primaryNetworkConnection,attr,omitempty"`
+	IpAddressingMode    string   `xml:"ipAddressingMode,attr,omitempty"`
+	NetworkName         string   `xml:",chardata"`
+}
+
+// HostResource info from ResourceType=17 (Hard Disk) 
+type VirtualHardwareHostResource struct {
+	BusType             int      `xml:"busType,attr,omitempty"`
+	BusSubType          string   `xml:"busSubType,attr,omitempty"`
+	Capacity            int      `xml:"capacity,attr,omitempty"`
+	StorageProfile      string   `xml:"storageProfileHref,attr,omitempty"`
+	OverrideVmDefault   bool     `xml:"storageProfileOverrideVmDefault,attr,omitempty"`
+}
+
+// SnapshotSection from VM struct
+type SnapshotSection struct {
+	// Extends OVF Section_Type
+	XMLName                  xml.Name              `xml:"SnapshotSection"`
+	Info                     string                `xml:"Info"`
+	HREF                     string                `xml:"href,attr,omitempty"`
+	Type                     string                `xml:"type,attr,omitempty"`
+	Snapshot              []*SnapshotItem          `xml:"Snapshot,omitempty"`
+}
+
+// Each snapshot listed in the SnapshotSection
+type SnapshotItem struct {
+	Created         string   `xml:"created,attr,omitempty"`
+	PoweredOn       bool     `xml:"poweredOn,attr,omitempty"`
+	Size            int      `xml:"size,attr,omitempty"`
 }
 
 // OVFItem is a horrible kludge to process OVF, needs to be fixed with proper types.

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -1493,6 +1493,21 @@ type QueryResultEdgeGatewayRecordsType struct {
 	EdgeGatewayRecord *QueryResultEdgeGatewayRecordType `xml:"EdgeGatewayRecord"` // A record representing a query result.
 }
 
+type QueryResultRecordsType struct {
+	// Attributes
+	HREF     string  `xml:"href,attr,omitempty"`     // The URI of the entity.
+	Type     string  `xml:"type,attr,omitempty"`     // The MIME type of the entity.
+	Name     string  `xml:"name,attr,omitempty"`     // The name of the entity.
+	Page     int     `xml:"page,attr,omitempty"`     // Page of the result set that this container holds. The first page is page number 1.
+	PageSize int     `xml:"pageSize,attr,omitempty"` // Page size, as a number of records or references.
+	Total    float64 `xml:"total,attr,omitempty"`    // Total number of records or references in the container.
+	// Elements
+	Link              []*Link                           `xml:"Link,omitempty"`    // A reference to an entity or operation associated with this object.
+	EdgeGatewayRecord *QueryResultEdgeGatewayRecordType `xml:"EdgeGatewayRecord"` // A record representing a query result.
+	VMRecord          []*QueryResultVMRecordType        `xml:"VMRecord"`          // A record representing a VM result.
+}
+
+
 // QueryResultEdgeGatewayRecordType represents an edge gateway record as query result.
 type QueryResultEdgeGatewayRecordType struct {
 	// Attributes
@@ -1505,4 +1520,34 @@ type QueryResultEdgeGatewayRecordType struct {
 	IsBusy              bool   `xml:"isBusy,attr"`                        // True if this Edge Gateway is busy.	Yes	Yes
 	GatewayStatus       string `xml:"gatewayStatus,attr,omitempty"`       //
 	HaStatus            string `xml:"haStatus,attr,omitempty"`            // High Availability Status of the edgeGateway	Yes	Yes
+}
+
+// QueryResultVMRecordType represents a VM record as query result.
+type QueryResultVMRecordType struct {
+	// Attributes
+	HREF                string `xml:"href,attr,omitempty"`                // The URI of the entity.
+	Name                string `xml:"name,attr,omitempty"`                // VM name.
+	Deployed            bool   `xml:"isDeployed,attr,omitempty"`          // True if the virtual machine is deployed.
+	Status              string `xml:"status,attr,omitempty"`
+	Busy                bool   `xml:"isBusy,attr,omitempty"`
+	Deleted             bool   `xml:"isDeleted,attr,omitempty"`
+	MaintenanceMode     bool   `xml:"isInMaintenanceMode,attr,omitempty"`
+	Published           bool   `xml:"isPublished,attr,omitempty"`
+	VAppTemplate        bool   `xml:"isVAppTemplate,attr,omitempty"`
+	VdcEnabled          bool   `xml:"isVdcEnabled,attr,omitempty"`
+	VdcHREF             string `xml:"vdc,attr,omitempty"`
+	VAppParentHREF      string `xml:"container,attr,omitempty"`
+	VAppParentName      string `xml:"containerName,attr,omitempty"`
+	HardwareVersion     int    `xml:"hardwareVersion,attr,omitempty"`
+	HighestSupportedVersion int `xml:"pvdcHighestSupportedHardwareVersion,attr,omitempty"`
+	VmToolsVersion      string `xml:"vmToolsVersion,attr,omitempty"`
+	GuestOS             string `xml:"guestOs,attr,omitempty"`
+	MemoryMB            int    `xml:"memoryMB,attr,omitempty"`
+	Cpus                int    `xml:"numberOfCpus,attr,omitempty"`
+	StorageProfileName  string `xml:"storageProfileName,attr,omitempty"`
+	NetworkName         string `xml:"networkName,attr,omitempty"`
+	TaskHREF            string `xml:"task,attr,omitempty"`
+	TaskStatusName      string `xml:"taskStatusName,attr,omitempty"`
+	TaskDetails         string `xml:"taskDetails,attr,omitempty"`
+	TaskStatus          string `xml:"TaskStatus,attr,omitempty"`
 }

--- a/types/v56/types.go
+++ b/types/v56/types.go
@@ -268,9 +268,9 @@ type NetworkConnection struct {
 type NetworkConnectionSection struct {
 	// Extends OVF Section_Type
 	// FIXME: Fix the OVF section
-	XMLName       xml.Name              `xml:"NetworkConnectionSection"`
-	Xmlns         string                `xml:"xmlns,attr,omitempty"`
-	Ovf     			string   							`xml:"xmlns:ovf,attr,omitempty"`
+	XMLName xml.Name `xml:"NetworkConnectionSection"`
+	Xmlns   string   `xml:"xmlns,attr,omitempty"`
+	Ovf     string   `xml:"xmlns:ovf,attr,omitempty"`
 
 	Info string `xml:"ovf:Info"`
 	//
@@ -317,7 +317,7 @@ type OrgVDCNetwork struct {
 	IsShared      bool                  `xml:"IsShared"`
 	Link          []Link                `xml:"Link,omitempty"`
 	ServiceConfig *GatewayFeatures      `xml:"ServiceConfig,omitempty"` // Specifies the service configuration for an isolated Org vDC networks
-	Tasks         *TasksInProgress       `xml:"Tasks,omitempty"`
+	Tasks         *TasksInProgress      `xml:"Tasks,omitempty"`
 }
 
 // SupportedHardwareVersions contains a list of VMware virtual hardware versions supported in this vDC.
@@ -767,15 +767,15 @@ type VApp struct {
 }
 
 type MetadataValue struct {
-	XMLName xml.Name `xml:"MetadataValue"`
-	Xsi     string   `xml:"xmlns:xsi,attr"`
-	Xmlns   string   `xml:"xmlns,attr"`
-	TypedValue *TypedValue	`xml:"TypedValue"`
+	XMLName    xml.Name    `xml:"MetadataValue"`
+	Xsi        string      `xml:"xmlns:xsi,attr"`
+	Xmlns      string      `xml:"xmlns,attr"`
+	TypedValue *TypedValue `xml:"TypedValue"`
 }
 
 type TypedValue struct {
-	XsiType		string		`xml:"xsi:type,attr"`
-	Value 		string 		`xml:"Value"`
+	XsiType string `xml:"xsi:type,attr"`
+	Value   string `xml:"Value"`
 }
 
 // VAppChildren is a container for virtual machines included in this vApp.
@@ -806,8 +806,6 @@ type VAppTemplateChildren struct {
 	// Elements
 	VM []*VAppTemplate `xml:"Vm"` // Represents a virtual machine in this vApp template.
 }
-
-
 
 // VAppTemplate represents a vApp template.
 // Type: VAppTemplateType
@@ -853,10 +851,10 @@ type VAppTemplate struct {
 // Since: 0.9
 type VM struct {
 	// Attributes
-	XMLName         xml.Name `xml:"Vm"`
-	Ovf   string `xml:"xmlns:ovf,attr,omitempty"`
-	Xsi   string `xml:"xmlns:xsi,attr,omitempty"`
-	Xmlns string `xml:"xmlns,attr,omitempty"`
+	XMLName xml.Name `xml:"Vm"`
+	Ovf     string   `xml:"xmlns:ovf,attr,omitempty"`
+	Xsi     string   `xml:"xmlns:xsi,attr,omitempty"`
+	Xmlns   string   `xml:"xmlns,attr,omitempty"`
 
 	HREF                    string `xml:"href,attr,omitempty"`                    // The URI of the entity.
 	Type                    string `xml:"type,attr,omitempty"`                    // The MIME type of the entity.
@@ -878,14 +876,14 @@ type VM struct {
 	DateCreated string `xml:"DateCreated,omitempty"` // Creation date/time of the vApp.
 
 	// Section ovf:VirtualHardwareSection
-	VirtualHardwareSection    *VirtualHardwareSection    `xml:"VirtualHardwareSection,omitempty"`
+	VirtualHardwareSection *VirtualHardwareSection `xml:"VirtualHardwareSection,omitempty"`
 
 	// FIXME: Upstream bug? Missing NetworkConnectionSection
 	NetworkConnectionSection *NetworkConnectionSection `xml:"NetworkConnectionSection,omitempty"`
 
 	VAppScopedLocalID string `xml:"VAppScopedLocalId,omitempty"` // A unique identifier for the virtual machine in the scope of the vApp.
 
-	Snapshots      *SnapshotSection `xml:"SnapshotSection,omitempty"`
+	Snapshots *SnapshotSection `xml:"SnapshotSection,omitempty"`
 
 	// TODO: OVF Sections to be implemented
 	// Environment OVF_Environment `xml:"Environment,omitempty"
@@ -897,68 +895,68 @@ type VM struct {
 // ovf:VirtualHardwareSection from VM struct
 type VirtualHardwareSection struct {
 	// Extends OVF Section_Type
-	XMLName                  xml.Name              `xml:"VirtualHardwareSection"`
-	Xmlns                    string                `xml:"vcloud,attr,omitempty"`
+	XMLName xml.Name `xml:"VirtualHardwareSection"`
+	Xmlns   string   `xml:"vcloud,attr,omitempty"`
 
-	Info                     string                `xml:"Info"`
-	HREF                     string                `xml:"href,attr,omitempty"`
-	Type                     string                `xml:"type,attr,omitempty"`
-	Item                   []*VirtualHardwareItem  `xml:"Item,omitempty"`
+	Info string                 `xml:"Info"`
+	HREF string                 `xml:"href,attr,omitempty"`
+	Type string                 `xml:"type,attr,omitempty"`
+	Item []*VirtualHardwareItem `xml:"Item,omitempty"`
 }
 
 // Each ovf:Item parsed from the ovf:VirtualHardwareSection
 type VirtualHardwareItem struct {
-	XMLName             xml.Name                     `xml:"Item"`
-	ResourceType        int                          `xml:"ResourceType,omitempty"`
-	ResourceSubType     string                       `xml:"ResourceSubType,omitempty"`
-	ElementName         string                       `xml:"ElementName,omitempty"`
-	Description         string                       `xml:"Description,omitempty"`
-	InstanceID          int                          `xml:"InstanceID,omitempty"`
-	AutomaticAllocation bool                         `xml:"AutomaticAllocation,omitempty"`
-	Address             string                       `xml:"Address,omitempty"`
-	AddressOnParent     int                          `xml:"AddressOnParent,omitempty"`
-	AllocationUnits     string                       `xml:"AllocationUnits,omitempty"`
-	Reservation         int                          `xml:"Reservation,omitempty"`
-	VirtualQuantity     int                          `xml:"VirtualQuantity,omitempty"`
-	Weight              int                          `xml:"Weight,omitempty"`
-	CoresPerSocket      int                          `xml:"CoresPerSocket,omitempty"`
-	Connection       []*VirtualHardwareConnection    `xml:"Connection,omitempty"`
-	HostResource     []*VirtualHardwareHostResource  `xml:"HostResource,omitempty"`
-	Link             []*Link                         `xml:"Link,omitempty"`
+	XMLName             xml.Name                       `xml:"Item"`
+	ResourceType        int                            `xml:"ResourceType,omitempty"`
+	ResourceSubType     string                         `xml:"ResourceSubType,omitempty"`
+	ElementName         string                         `xml:"ElementName,omitempty"`
+	Description         string                         `xml:"Description,omitempty"`
+	InstanceID          int                            `xml:"InstanceID,omitempty"`
+	AutomaticAllocation bool                           `xml:"AutomaticAllocation,omitempty"`
+	Address             string                         `xml:"Address,omitempty"`
+	AddressOnParent     int                            `xml:"AddressOnParent,omitempty"`
+	AllocationUnits     string                         `xml:"AllocationUnits,omitempty"`
+	Reservation         int                            `xml:"Reservation,omitempty"`
+	VirtualQuantity     int                            `xml:"VirtualQuantity,omitempty"`
+	Weight              int                            `xml:"Weight,omitempty"`
+	CoresPerSocket      int                            `xml:"CoresPerSocket,omitempty"`
+	Connection          []*VirtualHardwareConnection   `xml:"Connection,omitempty"`
+	HostResource        []*VirtualHardwareHostResource `xml:"HostResource,omitempty"`
+	Link                []*Link                        `xml:"Link,omitempty"`
 }
 
 // Connection info from ResourceType=10 (Network Interface)
 type VirtualHardwareConnection struct {
-	IPAddress           string   `xml:"ipAddress,attr,omitempty"`
-	PrimaryConnection   bool     `xml:"primaryNetworkConnection,attr,omitempty"`
-	IpAddressingMode    string   `xml:"ipAddressingMode,attr,omitempty"`
-	NetworkName         string   `xml:",chardata"`
+	IPAddress         string `xml:"ipAddress,attr,omitempty"`
+	PrimaryConnection bool   `xml:"primaryNetworkConnection,attr,omitempty"`
+	IpAddressingMode  string `xml:"ipAddressingMode,attr,omitempty"`
+	NetworkName       string `xml:",chardata"`
 }
 
-// HostResource info from ResourceType=17 (Hard Disk) 
+// HostResource info from ResourceType=17 (Hard Disk)
 type VirtualHardwareHostResource struct {
-	BusType             int      `xml:"busType,attr,omitempty"`
-	BusSubType          string   `xml:"busSubType,attr,omitempty"`
-	Capacity            int      `xml:"capacity,attr,omitempty"`
-	StorageProfile      string   `xml:"storageProfileHref,attr,omitempty"`
-	OverrideVmDefault   bool     `xml:"storageProfileOverrideVmDefault,attr,omitempty"`
+	BusType           int    `xml:"busType,attr,omitempty"`
+	BusSubType        string `xml:"busSubType,attr,omitempty"`
+	Capacity          int    `xml:"capacity,attr,omitempty"`
+	StorageProfile    string `xml:"storageProfileHref,attr,omitempty"`
+	OverrideVmDefault bool   `xml:"storageProfileOverrideVmDefault,attr,omitempty"`
 }
 
 // SnapshotSection from VM struct
 type SnapshotSection struct {
 	// Extends OVF Section_Type
-	XMLName                  xml.Name              `xml:"SnapshotSection"`
-	Info                     string                `xml:"Info"`
-	HREF                     string                `xml:"href,attr,omitempty"`
-	Type                     string                `xml:"type,attr,omitempty"`
-	Snapshot              []*SnapshotItem          `xml:"Snapshot,omitempty"`
+	XMLName  xml.Name        `xml:"SnapshotSection"`
+	Info     string          `xml:"Info"`
+	HREF     string          `xml:"href,attr,omitempty"`
+	Type     string          `xml:"type,attr,omitempty"`
+	Snapshot []*SnapshotItem `xml:"Snapshot,omitempty"`
 }
 
 // Each snapshot listed in the SnapshotSection
 type SnapshotItem struct {
-	Created         string   `xml:"created,attr,omitempty"`
-	PoweredOn       bool     `xml:"poweredOn,attr,omitempty"`
-	Size            int      `xml:"size,attr,omitempty"`
+	Created   string `xml:"created,attr,omitempty"`
+	PoweredOn bool   `xml:"poweredOn,attr,omitempty"`
+	Size      int    `xml:"size,attr,omitempty"`
 }
 
 // OVFItem is a horrible kludge to process OVF, needs to be fixed with proper types.
@@ -1132,11 +1130,11 @@ type SubnetParticipation struct {
 }
 
 type EdgeGatewayServiceConfiguration struct {
-	XMLName                xml.Name 					   `xml:"EdgeGatewayServiceConfiguration"`
-	Xmlns                  string                `xml:"xmlns,attr,omitempty"`
-	GatewayDhcpService     *GatewayDhcpService   `xml:"GatewayDhcpService,omitempty"`
-	FirewallService        *FirewallService      `xml:"FirewallService,omitempty"`
-	NatService 						 *NatService				   `xml:"NatService,omitempty"`
+	XMLName            xml.Name            `xml:"EdgeGatewayServiceConfiguration"`
+	Xmlns              string              `xml:"xmlns,attr,omitempty"`
+	GatewayDhcpService *GatewayDhcpService `xml:"GatewayDhcpService,omitempty"`
+	FirewallService    *FirewallService    `xml:"FirewallService,omitempty"`
+	NatService         *NatService         `xml:"NatService,omitempty"`
 }
 
 // GatewayFeatures represents edge gateway services.
@@ -1574,13 +1572,12 @@ type QueryResultRecordsType struct {
 	PageSize int     `xml:"pageSize,attr,omitempty"` // Page size, as a number of records or references.
 	Total    float64 `xml:"total,attr,omitempty"`    // Total number of records or references in the container.
 	// Elements
-	Link              []*Link                           `xml:"Link,omitempty"`    // A reference to an entity or operation associated with this object.
-	EdgeGatewayRecord *QueryResultEdgeGatewayRecordType `xml:"EdgeGatewayRecord"` // A record representing a query result.
-	VMRecord          []*QueryResultVMRecordType        `xml:"VMRecord"`          // A record representing a VM result.
-	VAppRecord        []*QueryResultVAppRecordType      `xml:"VAppRecord"`        // A record representing a VApp result.
+	Link                       []*Link                                      `xml:"Link,omitempty"`             // A reference to an entity or operation associated with this object.
+	EdgeGatewayRecord          *QueryResultEdgeGatewayRecordType            `xml:"EdgeGatewayRecord"`          // A record representing a query result.
+	VMRecord                   []*QueryResultVMRecordType                   `xml:"VMRecord"`                   // A record representing a VM result.
+	VAppRecord                 []*QueryResultVAppRecordType                 `xml:"VAppRecord"`                 // A record representing a VApp result.
 	OrgVdcStorageProfileRecord []*QueryResultOrgVdcStorageProfileRecordType `xml:"OrgVdcStorageProfileRecord"` // A record representing storage profiles
 }
-
 
 // QueryResultEdgeGatewayRecordType represents an edge gateway record as query result.
 type QueryResultEdgeGatewayRecordType struct {
@@ -1599,80 +1596,79 @@ type QueryResultEdgeGatewayRecordType struct {
 // QueryResultVMRecordType represents a VM record as query result.
 type QueryResultVMRecordType struct {
 	// Attributes
-	HREF                string `xml:"href,attr,omitempty"`                // The URI of the entity.
-	Name                string `xml:"name,attr,omitempty"`                // VM name.
-	Deployed            bool   `xml:"isDeployed,attr,omitempty"`          // True if the virtual machine is deployed.
-	Status              string `xml:"status,attr,omitempty"`
-	Busy                bool   `xml:"isBusy,attr,omitempty"`
-	Deleted             bool   `xml:"isDeleted,attr,omitempty"`
-	MaintenanceMode     bool   `xml:"isInMaintenanceMode,attr,omitempty"`
-	Published           bool   `xml:"isPublished,attr,omitempty"`
-	VAppTemplate        bool   `xml:"isVAppTemplate,attr,omitempty"`
-	VdcEnabled          bool   `xml:"isVdcEnabled,attr,omitempty"`
-	VdcHREF             string `xml:"vdc,attr,omitempty"`
-	VAppParentHREF      string `xml:"container,attr,omitempty"`
-	VAppParentName      string `xml:"containerName,attr,omitempty"`
-	HardwareVersion     int    `xml:"hardwareVersion,attr,omitempty"`
-	HighestSupportedVersion int `xml:"pvdcHighestSupportedHardwareVersion,attr,omitempty"`
-	VmToolsVersion      string `xml:"vmToolsVersion,attr,omitempty"`
-	GuestOS             string `xml:"guestOs,attr,omitempty"`
-	MemoryMB            int    `xml:"memoryMB,attr,omitempty"`
-	Cpus                int    `xml:"numberOfCpus,attr,omitempty"`
-	StorageProfileName  string `xml:"storageProfileName,attr,omitempty"`
-	NetworkName         string `xml:"networkName,attr,omitempty"`
-	TaskHREF            string `xml:"task,attr,omitempty"`
-	TaskStatusName      string `xml:"taskStatusName,attr,omitempty"`
-	TaskDetails         string `xml:"taskDetails,attr,omitempty"`
-	TaskStatus          string `xml:"TaskStatus,attr,omitempty"`
+	HREF                    string `xml:"href,attr,omitempty"`       // The URI of the entity.
+	Name                    string `xml:"name,attr,omitempty"`       // VM name.
+	Deployed                bool   `xml:"isDeployed,attr,omitempty"` // True if the virtual machine is deployed.
+	Status                  string `xml:"status,attr,omitempty"`
+	Busy                    bool   `xml:"isBusy,attr,omitempty"`
+	Deleted                 bool   `xml:"isDeleted,attr,omitempty"`
+	MaintenanceMode         bool   `xml:"isInMaintenanceMode,attr,omitempty"`
+	Published               bool   `xml:"isPublished,attr,omitempty"`
+	VAppTemplate            bool   `xml:"isVAppTemplate,attr,omitempty"`
+	VdcEnabled              bool   `xml:"isVdcEnabled,attr,omitempty"`
+	VdcHREF                 string `xml:"vdc,attr,omitempty"`
+	VAppParentHREF          string `xml:"container,attr,omitempty"`
+	VAppParentName          string `xml:"containerName,attr,omitempty"`
+	HardwareVersion         int    `xml:"hardwareVersion,attr,omitempty"`
+	HighestSupportedVersion int    `xml:"pvdcHighestSupportedHardwareVersion,attr,omitempty"`
+	VmToolsVersion          string `xml:"vmToolsVersion,attr,omitempty"`
+	GuestOS                 string `xml:"guestOs,attr,omitempty"`
+	MemoryMB                int    `xml:"memoryMB,attr,omitempty"`
+	Cpus                    int    `xml:"numberOfCpus,attr,omitempty"`
+	StorageProfileName      string `xml:"storageProfileName,attr,omitempty"`
+	NetworkName             string `xml:"networkName,attr,omitempty"`
+	TaskHREF                string `xml:"task,attr,omitempty"`
+	TaskStatusName          string `xml:"taskStatusName,attr,omitempty"`
+	TaskDetails             string `xml:"taskDetails,attr,omitempty"`
+	TaskStatus              string `xml:"TaskStatus,attr,omitempty"`
 }
 
 // QueryResultVAppRecordType represents a VM record as query result.
 type QueryResultVAppRecordType struct {
 	// Attributes
-	HREF                  string `xml:"href,attr,omitempty"`                  // The URI of the entity.
-	Name                  string `xml:"name,attr"`                            // The name of the entity.
-	CreationDate          string `xml:"creationDate,attr,omitempty"`          // Creation date/time of the vApp.
-	Busy                  bool   `xml:"isBusy,attr,omitempty"`
-	Deployed              bool   `xml:"isDeployed,attr,omitempty"`            // True if the vApp is deployed.
-	Enabled               bool   `xml:"isEnabled,attr,omitempty"`
-	Expired               bool   `xml:"isExpired,attr,omitempty"`
-	MaintenanceMode       bool   `xml:"isInMaintenanceMode,attr,omitempty"`
-	Public                bool   `xml:"isPublic,attr,omitempty"`
-	OwnerName             string `xml:"ownerName,attr,omitempty"`
-	Status                string `xml:"status,attr,omitempty"`
-	VdcHREF               string `xml:"vdc,attr,omitempty"`
-	VdcName               string `xml:"vdcName,attr,omitempty"`
-	NumberOfVMs           int    `xml:"numberOfVMs,attr,omitempty"`
-	NumberOfCPUs          int    `xml:"numberOfCpus,attr,omitempty"`
-	CpuAllocationMhz      int    `xml:"cpuAllocationMhz,attr,omitempty"`
-	CpuAllocationInMhz    int    `xml:"cpuAllocationInMhz,attr,omitempty"`
-	StorageKB             int    `xml:"storageKB,attr,omitempty"`
-	MemoryAllocationMB    int    `xml:"memoryAllocationMB,attr,omitempty"`
-	AutoDeleteNotified    bool   `xml:"isAutoDeleteNotified,attr,omitempty"`
-	AutoUndeployNotified  bool   `xml:"isAutoUndeployNotified,attr,omitempty"`
-	VdcEnabled            bool   `xml:"isVdcEnabled, attr,omitempty"`
-	HonorBootOrder        bool   `xml:"honorBookOrder,attr,omitempty"`
-	HighestSupportedVersion int `xml:"pvdcHighestSupportedHardwareVersion,attr,omitempty"`
-	LowestHardwareVersion int    `xml:"lowestHardwareVersionInVApp,attr,omitempty"`
-	TaskHREF              string `xml:"task,attr,omitempty"`
-	TaskStatusName        string `xml:"taskStatusName,attr,omitempty"`
-	TaskStatus            string `xml:"TaskStatus,attr,omitempty"`
-	TaskDetails           string `xml:"taskDetails,attr,omitempty"`
+	HREF                    string `xml:"href,attr,omitempty"`         // The URI of the entity.
+	Name                    string `xml:"name,attr"`                   // The name of the entity.
+	CreationDate            string `xml:"creationDate,attr,omitempty"` // Creation date/time of the vApp.
+	Busy                    bool   `xml:"isBusy,attr,omitempty"`
+	Deployed                bool   `xml:"isDeployed,attr,omitempty"` // True if the vApp is deployed.
+	Enabled                 bool   `xml:"isEnabled,attr,omitempty"`
+	Expired                 bool   `xml:"isExpired,attr,omitempty"`
+	MaintenanceMode         bool   `xml:"isInMaintenanceMode,attr,omitempty"`
+	Public                  bool   `xml:"isPublic,attr,omitempty"`
+	OwnerName               string `xml:"ownerName,attr,omitempty"`
+	Status                  string `xml:"status,attr,omitempty"`
+	VdcHREF                 string `xml:"vdc,attr,omitempty"`
+	VdcName                 string `xml:"vdcName,attr,omitempty"`
+	NumberOfVMs             int    `xml:"numberOfVMs,attr,omitempty"`
+	NumberOfCPUs            int    `xml:"numberOfCpus,attr,omitempty"`
+	CpuAllocationMhz        int    `xml:"cpuAllocationMhz,attr,omitempty"`
+	CpuAllocationInMhz      int    `xml:"cpuAllocationInMhz,attr,omitempty"`
+	StorageKB               int    `xml:"storageKB,attr,omitempty"`
+	MemoryAllocationMB      int    `xml:"memoryAllocationMB,attr,omitempty"`
+	AutoDeleteNotified      bool   `xml:"isAutoDeleteNotified,attr,omitempty"`
+	AutoUndeployNotified    bool   `xml:"isAutoUndeployNotified,attr,omitempty"`
+	VdcEnabled              bool   `xml:"isVdcEnabled, attr,omitempty"`
+	HonorBootOrder          bool   `xml:"honorBookOrder,attr,omitempty"`
+	HighestSupportedVersion int    `xml:"pvdcHighestSupportedHardwareVersion,attr,omitempty"`
+	LowestHardwareVersion   int    `xml:"lowestHardwareVersionInVApp,attr,omitempty"`
+	TaskHREF                string `xml:"task,attr,omitempty"`
+	TaskStatusName          string `xml:"taskStatusName,attr,omitempty"`
+	TaskStatus              string `xml:"TaskStatus,attr,omitempty"`
+	TaskDetails             string `xml:"taskDetails,attr,omitempty"`
 }
-
 
 // QueryResultOrgVdcStorageProfileRecordType represents a storage
 // profile as query result.
 type QueryResultOrgVdcStorageProfileRecordType struct {
 	// Attributes
-	HREF                string `xml:"href,attr,omitempty"`                // The URI of the entity.
-	Name                string `xml:"name,attr,omitempty"`                // Storage Profile name.
-	VdcHREF             string `xml:"vdc,attr,omitempty"`
-	VdcName             string `xml:"vdcName,attr,omitempty"`
-	IsDefaultStorageProfile bool `xml:"isDefaultStorageProfile,attr,omitempty"`
-	IsEnabled           bool   `xml:"isEnabled,attr,omitempty"`
-	IsVdcBusy           bool   `xml:"isVdcBusy,attr,omitempty"`
-	NumberOfConditions  int    `xml:"numberOfConditions,attr,omitempty"`
-	StorageUsedMB       int    `xml:"storageUsedMB,attr,omitempty"`
-	StorageLimitMB      int    `xml:"storageLimitMB,attr,omitempty"`
+	HREF                    string `xml:"href,attr,omitempty"` // The URI of the entity.
+	Name                    string `xml:"name,attr,omitempty"` // Storage Profile name.
+	VdcHREF                 string `xml:"vdc,attr,omitempty"`
+	VdcName                 string `xml:"vdcName,attr,omitempty"`
+	IsDefaultStorageProfile bool   `xml:"isDefaultStorageProfile,attr,omitempty"`
+	IsEnabled               bool   `xml:"isEnabled,attr,omitempty"`
+	IsVdcBusy               bool   `xml:"isVdcBusy,attr,omitempty"`
+	NumberOfConditions      int    `xml:"numberOfConditions,attr,omitempty"`
+	StorageUsedMB           int    `xml:"storageUsedMB,attr,omitempty"`
+	StorageLimitMB          int    `xml:"storageLimitMB,attr,omitempty"`
 }

--- a/vm.go
+++ b/vm.go
@@ -18,13 +18,13 @@ import (
 
 type VM struct {
 	VM *types.VM
-	c    *Client
+	c  *Client
 }
 
 func NewVM(c *Client) *VM {
 	return &VM{
 		VM: new(types.VM),
-		c:    c,
+		c:  c,
 	}
 }
 
@@ -53,4 +53,3 @@ func (c *VCDClient) FindVMByHREF(vmhref string) (VM, error) {
 	return *newvm, nil
 
 }
-

--- a/vm.go
+++ b/vm.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014 VMware, Inc.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+	// "bytes"
+	// "encoding/xml"
+	"fmt"
+	// "log"
+	"net/url"
+	// "os"
+	// "strconv"
+
+	types "github.com/hmrc/vmware-govcd/types/v56"
+)
+
+type VM struct {
+	VM *types.VM
+	c    *Client
+}
+
+func NewVM(c *Client) *VM {
+	return &VM{
+		VM: new(types.VM),
+		c:    c,
+	}
+}
+
+func (c *VCDClient) FindVMByHREF(vmhref string) (VM, error) {
+
+	u, err := url.ParseRequestURI(vmhref)
+
+	if err != nil {
+		return VM{}, fmt.Errorf("error decoding vm HREF: %s", err)
+	}
+
+	// Querying the VApp
+	req := c.Client.NewRequest(map[string]string{}, "GET", *u, nil)
+
+	resp, err := checkResp(c.Client.Http.Do(req))
+	if err != nil {
+		return VM{}, fmt.Errorf("error retrieving VM: %s", err)
+	}
+
+	newvm := NewVM(&c.Client)
+
+	if err = decodeBody(resp, newvm.VM); err != nil {
+		return VM{}, fmt.Errorf("error decoding VM response: %s", err)
+	}
+
+	return *newvm, nil
+
+}
+

--- a/vm_test.go
+++ b/vm_test.go
@@ -5,9 +5,9 @@
 package govcd
 
 import (
- 	// "fmt"
-	. "gopkg.in/check.v1"
+	// "fmt"
 	"github.com/hmrc/vmware-govcd/testutil"
+	. "gopkg.in/check.v1"
 )
 
 func (s *K) Test_FindVMByHREF(c *C) {
@@ -24,7 +24,7 @@ func (s *K) Test_FindVMByHREF(c *C) {
 
 	c.Assert(err, IsNil)
 	c.Assert(vm.VM.Name, Equals, "testvmxnet")
-	c.Assert(vm.VM.VirtualHardwareSection.Item, NotNil )
+	c.Assert(vm.VM.VirtualHardwareSection.Item, NotNil)
 }
 
 var vmExample = `<?xml version="1.0" encoding="UTF-8"?>

--- a/vm_test.go
+++ b/vm_test.go
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2016 Skyscape Cloud Services.  All rights reserved.  Licensed under the Apache v2 License.
+ */
+
+package govcd
+
+import (
+ 	// "fmt"
+	. "gopkg.in/check.v1"
+	"github.com/hmrc/vmware-govcd/testutil"
+)
+
+func (s *K) Test_FindVMByHREF(c *C) {
+
+	// Get the Org populated
+	testServer.ResponseMap(1, testutil.ResponseMap{
+		"/api/vApp/vm-11111111-1111-1111-1111-111111111111": testutil.Response{200, nil, vmExample},
+	})
+
+	vm_href := vcdu_api.String() + "/vApp/vm-11111111-1111-1111-1111-111111111111"
+	vm, err := s.client.FindVMByHREF(vm_href)
+	_ = testServer.WaitRequest()
+	testServer.Flush()
+
+	c.Assert(err, IsNil)
+	c.Assert(vm.VM.Name, Equals, "testvmxnet")
+	c.Assert(vm.VM.VirtualHardwareSection.Item, NotNil )
+}
+
+var vmExample = `<?xml version="1.0" encoding="UTF-8"?>
+<Vm xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" xmlns:vssd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:vmw="http://www.vmware.com/schema/ovf" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" needsCustomization="true" nestedHypervisorEnabled="false" deployed="false" status="8" name="testvmxnet" id="urn:vcloud:vm:11111111-1111-1111-1111-111111111111" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111" type="application/vnd.vmware.vcloud.vm+xml" xsi:schemaLocation="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_VirtualSystemSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_VirtualSystemSettingData.xsd http://www.vmware.com/schema/ovf http://www.vmware.com/schema/ovf http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://10.10.6.11/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
+    <Link rel="power:powerOn" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/power/action/powerOn"/>
+    <Link rel="deploy" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/action/deploy" type="application/vnd.vmware.vcloud.deployVAppParams+xml"/>
+    <Link rel="edit" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111" type="application/vnd.vmware.vcloud.vm+xml"/>
+    <Link rel="remove" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111"/>
+    <Link rel="down" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/metadata" type="application/vnd.vmware.vcloud.metadata+xml"/>
+    <Link rel="down" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/productSections/" type="application/vnd.vmware.vcloud.productSections+xml"/>
+    <Link rel="down" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/metrics/historic" type="application/vnd.vmware.vcloud.metrics.historicUsageSpec+xml"/>
+    <Link rel="metrics" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/metrics/historic" type="application/vnd.vmware.vcloud.metrics.historicUsageSpec+xml"/>
+    <Link rel="screen:thumbnail" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/screen"/>
+    <Link rel="media:insertMedia" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/media/action/insertMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+    <Link rel="media:ejectMedia" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/media/action/ejectMedia" type="application/vnd.vmware.vcloud.mediaInsertOrEjectParams+xml"/>
+    <Link rel="disk:attach" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/disk/action/attach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+    <Link rel="disk:detach" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/disk/action/detach" type="application/vnd.vmware.vcloud.diskAttachOrDetachParams+xml"/>
+    <Link rel="enable" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/action/enableNestedHypervisor"/>
+    <Link rel="customizeAtNextPowerOn" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/action/customizeAtNextPowerOn"/>
+    <Link rel="snapshot:create" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/action/createSnapshot" type="application/vnd.vmware.vcloud.createSnapshotParams+xml"/>
+    <Link rel="reconfigureVm" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/action/reconfigureVm" name="testvmxnet" type="application/vnd.vmware.vcloud.vm+xml"/>
+    <Link rel="up" href="http://localhost:4444/api/vApp/vapp-22222222-2222-2222-2222-222222222222" type="application/vnd.vmware.vcloud.vApp+xml"/>
+    <Description/>
+    <ovf:VirtualHardwareSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:transport="" vcloud:href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
+        <ovf:Info>Virtual hardware requirements</ovf:Info>
+        <ovf:System>
+            <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
+            <vssd:InstanceID>0</vssd:InstanceID>
+            <vssd:VirtualSystemIdentifier>testvmxnet</vssd:VirtualSystemIdentifier>
+            <vssd:VirtualSystemType>vmx-09</vssd:VirtualSystemType>
+        
+        </ovf:System>
+        <ovf:Item>
+            <rasd:Address>00:50:56:01:35:88</rasd:Address>
+            <rasd:AddressOnParent>1</rasd:AddressOnParent>
+            <rasd:AutomaticAllocation>true</rasd:AutomaticAllocation>
+            <rasd:Connection vcloud:ipAddress="10.40.0.11" vcloud:primaryNetworkConnection="true" vcloud:ipAddressingMode="POOL">Development Network</rasd:Connection>
+            <rasd:Description>Vmxnet3 ethernet adapter on "Development Network"</rasd:Description>
+            <rasd:ElementName>Network adapter 1</rasd:ElementName>
+            <rasd:InstanceID>1</rasd:InstanceID>
+            <rasd:ResourceSubType>VMXNET3</rasd:ResourceSubType>
+            <rasd:ResourceType>10</rasd:ResourceType>
+        
+        </ovf:Item>
+        <ovf:Item>
+            <rasd:Address>0</rasd:Address>
+            <rasd:Description>SCSI Controller</rasd:Description>
+            <rasd:ElementName>SCSI Controller 0</rasd:ElementName>
+            <rasd:InstanceID>2</rasd:InstanceID>
+            <rasd:ResourceSubType>lsilogic</rasd:ResourceSubType>
+            <rasd:ResourceType>6</rasd:ResourceType>
+        
+        </ovf:Item>
+        <ovf:Item>
+            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+            <rasd:Description>Hard disk</rasd:Description>
+            <rasd:ElementName>Hard disk 1</rasd:ElementName>
+            <rasd:HostResource vcloud:capacity="65536" vcloud:storageProfileOverrideVmDefault="false" vcloud:busSubType="lsilogic" vcloud:storageProfileHref="http://localhost:4444/api/vdcStorageProfile/33333333-3333-3333-3333-333333333333" vcloud:busType="6"/>
+            <rasd:InstanceID>2000</rasd:InstanceID>
+            <rasd:Parent>2</rasd:Parent>
+            <rasd:ResourceType>17</rasd:ResourceType>
+        
+        </ovf:Item>
+        <ovf:Item>
+            <rasd:Address>1</rasd:Address>
+            <rasd:Description>IDE Controller</rasd:Description>
+            <rasd:ElementName>IDE Controller 1</rasd:ElementName>
+            <rasd:InstanceID>3</rasd:InstanceID>
+            <rasd:ResourceType>5</rasd:ResourceType>
+        
+        </ovf:Item>
+        <ovf:Item>
+            <rasd:AddressOnParent>0</rasd:AddressOnParent>
+            <rasd:AutomaticAllocation>false</rasd:AutomaticAllocation>
+            <rasd:Description>CD/DVD Drive</rasd:Description>
+            <rasd:ElementName>CD/DVD Drive 1</rasd:ElementName>
+            <rasd:HostResource/>
+            <rasd:InstanceID>3002</rasd:InstanceID>
+            <rasd:Parent>3</rasd:Parent>
+            <rasd:ResourceType>15</rasd:ResourceType>
+        
+        </ovf:Item>
+        <ovf:Item vcloud:href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/cpu" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
+            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
+            <rasd:Description>Number of Virtual CPUs</rasd:Description>
+            <rasd:ElementName>1 virtual CPU(s)</rasd:ElementName>
+            <rasd:InstanceID>4</rasd:InstanceID>
+            <rasd:Reservation>0</rasd:Reservation>
+            <rasd:ResourceType>3</rasd:ResourceType>
+            <rasd:VirtualQuantity>1</rasd:VirtualQuantity>
+            <rasd:Weight>0</rasd:Weight>
+            <vmw:CoresPerSocket ovf:required="false">1</vmw:CoresPerSocket>
+            <Link rel="edit" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+        
+        </ovf:Item>
+        <ovf:Item vcloud:href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/memory" vcloud:type="application/vnd.vmware.vcloud.rasdItem+xml">
+            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
+            <rasd:Description>Memory Size</rasd:Description>
+            <rasd:ElementName>512 MB of memory</rasd:ElementName>
+            <rasd:InstanceID>5</rasd:InstanceID>
+            <rasd:Reservation>0</rasd:Reservation>
+            <rasd:ResourceType>4</rasd:ResourceType>
+            <rasd:VirtualQuantity>512</rasd:VirtualQuantity>
+            <rasd:Weight>0</rasd:Weight>
+            <Link rel="edit" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+        
+        </ovf:Item>
+        <Link rel="edit" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/" type="application/vnd.vmware.vcloud.virtualHardwareSection+xml"/>
+        <Link rel="down" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+        <Link rel="edit" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/cpu" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+        <Link rel="down" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+        <Link rel="edit" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/memory" type="application/vnd.vmware.vcloud.rasdItem+xml"/>
+        <Link rel="down" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+        <Link rel="edit" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/disks" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+        <Link rel="down" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/media" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+        <Link rel="down" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+        <Link rel="edit" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/networkCards" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+        <Link rel="down" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+        <Link rel="edit" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/virtualHardwareSection/serialPorts" type="application/vnd.vmware.vcloud.rasdItemsList+xml"/>
+    
+    </ovf:VirtualHardwareSection>
+    <ovf:OperatingSystemSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" ovf:id="101" vcloud:href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/operatingSystemSection/" vcloud:type="application/vnd.vmware.vcloud.operatingSystemSection+xml" vmw:osType="centos64Guest">
+        <ovf:Info>Specifies the operating system installed</ovf:Info>
+        <ovf:Description>CentOS 4/5/6/7 (64-bit)</ovf:Description>
+        <Link rel="edit" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/operatingSystemSection/" type="application/vnd.vmware.vcloud.operatingSystemSection+xml"/>
+    
+    </ovf:OperatingSystemSection>
+    <NetworkConnectionSection href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" ovf:required="false">
+        <ovf:Info>Specifies the available VM network connections</ovf:Info>
+        <PrimaryNetworkConnectionIndex>1</PrimaryNetworkConnectionIndex>
+        <NetworkConnection needsCustomization="true" network="Development Network">
+            <NetworkConnectionIndex>1</NetworkConnectionIndex>
+            <IpAddress>10.40.0.11</IpAddress>
+            <IsConnected>true</IsConnected>
+            <MACAddress>00:50:56:01:35:88</MACAddress>
+            <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+        
+        </NetworkConnection>
+        <Link rel="edit" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/networkConnectionSection/" type="application/vnd.vmware.vcloud.networkConnectionSection+xml"/>
+    
+    </NetworkConnectionSection>
+    <GuestCustomizationSection href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml" ovf:required="false">
+        <ovf:Info>Specifies Guest OS Customization Settings</ovf:Info>
+        <Enabled>true</Enabled>
+        <ChangeSid>false</ChangeSid>
+        <VirtualMachineId>11111111-1111-1111-1111-111111111111</VirtualMachineId>
+        <JoinDomainEnabled>false</JoinDomainEnabled>
+        <UseOrgSettings>false</UseOrgSettings>
+        <AdminPasswordEnabled>true</AdminPasswordEnabled>
+        <AdminPasswordAuto>true</AdminPasswordAuto>
+        <AdminAutoLogonEnabled>false</AdminAutoLogonEnabled>
+        <AdminAutoLogonCount>0</AdminAutoLogonCount>
+        <ResetPasswordRequired>false</ResetPasswordRequired>
+        <ComputerName>testvmxnet3</ComputerName>
+        <Link rel="edit" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/guestCustomizationSection/" type="application/vnd.vmware.vcloud.guestCustomizationSection+xml"/>
+    
+    </GuestCustomizationSection>
+    <RuntimeInfoSection xmlns:vcloud="http://www.vmware.com/vcloud/v1.5" vcloud:href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/runtimeInfoSection" vcloud:type="application/vnd.vmware.vcloud.virtualHardwareSection+xml">
+        <ovf:Info>Specifies Runtime info</ovf:Info>
+        <VMWareTools version="2147483647"/>
+    
+    </RuntimeInfoSection>
+    <SnapshotSection href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/snapshotSection" type="application/vnd.vmware.vcloud.snapshotSection+xml" ovf:required="false">
+        <ovf:Info>Snapshot information section</ovf:Info>
+    
+    </SnapshotSection>
+    <VAppScopedLocalId>vm</VAppScopedLocalId>
+    <VmCapabilities href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml">
+        <Link rel="edit" href="http://localhost:4444/api/vApp/vm-11111111-1111-1111-1111-111111111111/vmCapabilities/" type="application/vnd.vmware.vcloud.vmCapabilitiesSection+xml"/>
+        <MemoryHotAddEnabled>false</MemoryHotAddEnabled>
+        <CpuHotAddEnabled>false</CpuHotAddEnabled>
+    
+    </VmCapabilities>
+    <StorageProfile href="http://localhost:4444/api/vdcStorageProfile/33333333-3333-3333-3333-333333333333" name="BASIC-Any" type="application/vnd.vmware.vcloud.vdcStorageProfile+xml"/>
+</Vm>
+	`


### PR DESCRIPTION
This is work that is on-going. I've only added a handful of structures to support the many variants of query results the API can return. Feel free to provide feedback on the direction I've taken or if it is even the right thing. 

My intention is to be able to use the govcd library with code like the following:

``` go
  client, err := config.Client() // We now have a client
  if err != nil {
      fmt.Println(err)
      os.Exit(1)
  }

  results, err := client.Query(map[string]string{"type": "vm"})
  fmt.Printf("Results: %d\n", int(results.Results.Total))
  for _, s := range results.Results.VMRecord {
    fmt.Printf("Name: %s VMVersion: %d ToolsVersion: %s\n", s.Name, s.HardwareVersion, s.VmToolsVersion)
    if s.VAppTemplate == false {
      VM, err := client.FindVMByHREF(s.HREF)
    }
  }
```
